### PR TITLE
fix: 업로드 파일명 추가

### DIFF
--- a/src/main/java/com/boostcamp/zzimkong/controller/FileUploadApiController.java
+++ b/src/main/java/com/boostcamp/zzimkong/controller/FileUploadApiController.java
@@ -40,13 +40,12 @@ public class FileUploadApiController {
     ) {
         RawFileData rawFileData = FileConverter.convertVideoFile(
                 videoUploadRequest.getFile(),
-                uuidHolder,
-                videoUploadRequest.getTitle()
+                uuidHolder
         );
         String videoUploadUrl = gcpFileUploader.uploadVideo(rawFileData);
 
         VideoFileSaveResponse videoFileSaveResponse =
-                fileService.save(videoUploadRequest.getId(), rawFileData.getUploadFileName(), videoUploadUrl);
+                fileService.save(videoUploadRequest.getId(), videoUploadRequest.getTitle(), videoUploadUrl);
         return ResponseEntity
                 .created(URI.create("/api/video/" + videoFileSaveResponse.getId()))
                 .body(videoFileSaveResponse);
@@ -58,13 +57,12 @@ public class FileUploadApiController {
     ) {
         List<RawFileData> rawFileDatas = FileConverter.convertImageFiles(
                 imageUploadRequest.getFiles(),
-                uuidHolder,
-                imageUploadRequest.getTitle()
+                uuidHolder
         );
         List<String> imageUploadUrls = gcpFileUploader.uploadImages(rawFileDatas);
 
         ImageFileSaveResponses imageFileSaveResponses =
-                fileService.save(imageUploadRequest.getId(), rawFileDatas, imageUploadUrls);
+                fileService.save(imageUploadRequest.getId(), imageUploadRequest.getTitle(), imageUploadUrls);
 
         return ResponseEntity
                 .ok(imageFileSaveResponses);

--- a/src/main/java/com/boostcamp/zzimkong/domain/furniture/FurnitureUploadFile.java
+++ b/src/main/java/com/boostcamp/zzimkong/domain/furniture/FurnitureUploadFile.java
@@ -29,8 +29,8 @@ public class FurnitureUploadFile extends BaseEntity {
 
     public FurnitureUploadFile(
             User user,
-            String storeFileUrl,
-            String uploadFileName
+            String uploadFileName,
+            String storeFileUrl
     ) {
         this.user = user;
         this.storeFileUrl = storeFileUrl;

--- a/src/main/java/com/boostcamp/zzimkong/exception/InvalidDurationException.java
+++ b/src/main/java/com/boostcamp/zzimkong/exception/InvalidDurationException.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 public class InvalidDurationException extends ZzimkongException {
     public InvalidDurationException() {
         super(
-                "영상 길이는 10분 이상만 가능합니다.",
-                "영상 길이는 10분 이상만 가능합니다.",
+                "영상 길이는 2분 이상 10분 이하만 가능합니다.",
+                "영상 길이는 2분 이상 10분 이하만 가능합니다.",
                 HttpStatus.BAD_REQUEST,
                 "4004"
         );

--- a/src/main/java/com/boostcamp/zzimkong/service/FileService.java
+++ b/src/main/java/com/boostcamp/zzimkong/service/FileService.java
@@ -48,14 +48,14 @@ public class FileService {
         return VideoFileSaveResponse.from(saveSpaceUploadFile);
     }
 
-    public ImageFileSaveResponses save(Long userId, List<RawFileData> rawFileDatas, List<String> imageUploadUrls) {
+    public ImageFileSaveResponses save(Long userId, String uploadFileName, List<String> imageUploadUrls) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchMemberException(userId));
 
         List<FurnitureUploadFile> furnitureUploadFiles = IntStream.range(START, imageUploadUrls.size())
                 .mapToObj(idx -> new FurnitureUploadFile(
                         findUser,
-                        rawFileDatas.get(idx).getUploadFileName(),
+                        uploadFileName,
                         imageUploadUrls.get(idx))
                 ).collect(Collectors.toList());
 

--- a/src/main/java/com/boostcamp/zzimkong/support/file/FileConverter.java
+++ b/src/main/java/com/boostcamp/zzimkong/support/file/FileConverter.java
@@ -11,17 +11,19 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class FileConverter {
-    public static RawFileData convertVideoFile(final MultipartFile file, final UuidHolder uuidHolder, final String title) {
+    public static RawFileData convertVideoFile(final MultipartFile file, final UuidHolder uuidHolder) {
         if (file == null || file.isEmpty()) {
             return null;
         }
 
+        final String filename = file.getOriginalFilename();
+
         try {
             return new RawFileData(
-                    title,
+                    filename,
                     uuidHolder.random(),
                     file.getContentType(),
-                    FileExtension.getExtensionFromFileName(title),
+                    FileExtension.getExtensionFromFileName(filename),
                     file.getInputStream()
             );
         } catch (IOException e) {
@@ -29,7 +31,7 @@ public class FileConverter {
         }
     }
 
-    public static List<RawFileData> convertImageFiles(final List<MultipartFile> files, final UuidHolder uuidHolder, final String title) {
+    public static List<RawFileData> convertImageFiles(final List<MultipartFile> files, final UuidHolder uuidHolder) {
         if (CollectionUtils.isEmpty(files)) {
             return List.of();
         }
@@ -38,11 +40,13 @@ public class FileConverter {
                 .map(
                         file -> {
                             try {
+                                final String filename = file.getOriginalFilename();
+
                                 return new RawFileData(
-                                        title,
+                                        filename,
                                         uuidHolder.random(),
                                         file.getContentType(),
-                                        FileExtension.getExtensionFromFileName(title),
+                                        FileExtension.getExtensionFromFileName(filename),
                                         file.getInputStream()
                                 );
                             } catch (IOException e) {


### PR DESCRIPTION
## Overview
- 사용자 파일명 입력 버그를 해결합니다.

## Change log
- FileService
- FileConverter
- FileUploadApiController

## To Reviewer
- 스토리지에는 파일 메타 데이터를 사용하고 sql에는 사용자 입력을 사용하도록 수정하였습니다. 하기 파일 업로드 결과 사용자 입력이 저장됩니다.
- 파일 업로드 수행
![image](https://github.com/bcatcv5/zzimkong-backend/assets/90328527/74923fdc-ebe9-4ffb-a2ba-27eb97a969a1)

- 파일 업로드 결과
![image](https://github.com/bcatcv5/zzimkong-backend/assets/90328527/d955baae-5531-4559-9e27-434dd487b6a6)


## Issue Tags
- fixed: #11 
- see also: #6  
