### PR TITLE
feat: interior items response 파일명 추가

### DIFF
--- a/src/main/java/com/boostcamp/zzimkong/controller/dto/interior/GalleryObjectListResponse.java
+++ b/src/main/java/com/boostcamp/zzimkong/controller/dto/interior/GalleryObjectListResponse.java
@@ -11,6 +11,7 @@ import lombok.ToString;
 public class GalleryObjectListResponse {
     private Long id;;
     private String userName;
+    private String uploadFileName;
     private StatusCode statusCode;
     private String statusMessage;
     private String storeFileUrl;

--- a/src/main/java/com/boostcamp/zzimkong/controller/dto/interior/ObjectListResponse.java
+++ b/src/main/java/com/boostcamp/zzimkong/controller/dto/interior/ObjectListResponse.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 @AllArgsConstructor
 public class ObjectListResponse{
     private Long id;;
+    private String uploadFileName;
     private StatusCode statusCode;
     private String statusMessage;
     private String storeFileUrl;

--- a/src/main/java/com/boostcamp/zzimkong/repository/modelresult/FurnitureResultRepository.java
+++ b/src/main/java/com/boostcamp/zzimkong/repository/modelresult/FurnitureResultRepository.java
@@ -26,6 +26,7 @@ public interface FurnitureResultRepository extends JpaRepository<FurnitureModelR
             select
             new com.boostcamp.zzimkong.controller.dto.interior.ObjectListResponse(
                 smr.id,
+                smr.uploadFileName,
                 smr.statusCode,
                 smr.statusMessage,
                 smr.storeFileUrl,
@@ -45,6 +46,7 @@ public interface FurnitureResultRepository extends JpaRepository<FurnitureModelR
             new com.boostcamp.zzimkong.controller.dto.interior.GalleryObjectListResponse(
                 smr.id,
                 user.name,
+                smr.uploadFileName,
                 smr.statusCode,
                 smr.statusMessage,
                 smr.storeFileUrl,

--- a/src/main/java/com/boostcamp/zzimkong/repository/modelresult/SpaceResultRepository.java
+++ b/src/main/java/com/boostcamp/zzimkong/repository/modelresult/SpaceResultRepository.java
@@ -26,6 +26,7 @@ public interface SpaceResultRepository extends JpaRepository<SpaceModelResult, L
             select
             new com.boostcamp.zzimkong.controller.dto.interior.ObjectListResponse(
                 smr.id,
+                smr.uploadFileName,
                 smr.statusCode,
                 smr.statusMessage,
                 smr.storeFileUrl,
@@ -45,6 +46,7 @@ public interface SpaceResultRepository extends JpaRepository<SpaceModelResult, L
             new com.boostcamp.zzimkong.controller.dto.interior.GalleryObjectListResponse(
                 smr.id,
                 user.name,
+                smr.uploadFileName,
                 smr.statusCode,
                 smr.statusMessage,
                 smr.storeFileUrl,


### PR DESCRIPTION
## Overview
- 기존에 반환하던 interior items response에 파일명을 추가합니다.

## Change log
- ObjectListResponse
- GalleryObjectListResponse
- FurnitureResultRepository
- SpaceResultRepository

## To Reviewer
- interior items 조회 수행
<img width="701" alt="스크린샷 2024-03-24 16 18 34" src="https://github.com/bcatcv5/zzimkong-backend/assets/79568286/d2f99f40-6639-43ad-81bd-bbacdfc343c4">

- interior items 조회 결과
<img width="669" alt="스크린샷 2024-03-24 16 19 07" src="https://github.com/bcatcv5/zzimkong-backend/assets/79568286/e5f48413-8742-48a2-acdc-00919794dfa7">

## Issue Tags
- closed: #23 
