### PR TITLE
feat: 로그인 상태 인증(authentication) 기능 구현

### DIFF
--- a/src/main/java/com/boostcamp/zzimkong/controller/auth/AuthApiController.java
+++ b/src/main/java/com/boostcamp/zzimkong/controller/auth/AuthApiController.java
@@ -1,0 +1,19 @@
+package com.boostcamp.zzimkong.controller.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthApiController {
+    @GetMapping()
+    public ResponseEntity<Void> authentication() {
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
## Overview
- 유저의 로그인 상태를 인증(authentication)합니다.

## Change log
- AuthApiController

## To Reviewer
- FE에서 로그인 상태를 지속적으로 확인 받기 위한 api입니다.
- jwt 토큰을 검증하여 response status code로 200 또는 401을 반환합니다.
- 추후 쿼리 파라미터 등을 추가하여 활동 추적에 사용할 수 있습니다.

## Issue Tags
- see also: #25 
