### PR TITLE
fix: async upload 기능 구현

### DIFF
--- a/src/main/java/com/boostcamp/zzimkong/config/AsyncConfig.java
+++ b/src/main/java/com/boostcamp/zzimkong/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.boostcamp.zzimkong.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/boostcamp/zzimkong/config/batch/FurnitureBatchConfig.java
+++ b/src/main/java/com/boostcamp/zzimkong/config/batch/FurnitureBatchConfig.java
@@ -42,7 +42,7 @@ public class FurnitureBatchConfig {
     @Bean
     public Step finishFurnitureStep(JobRepository jobRepository) {
         return new StepBuilder("finishFurnitureStep", jobRepository)
-                .<FurnitureModelResult, FurnitureModelResult> chunk(500, transactionManager)
+                .<FurnitureModelResult, FurnitureModelResult> chunk(100, transactionManager)
                 .reader(readerFurniture())
                 .writer(writerFurniture())
                 .build();
@@ -55,7 +55,7 @@ public class FurnitureBatchConfig {
         reader.setMethodName("findByStatusPushed");
         reader.setArguments(Collections.singletonList(false));
         reader.setSort(Collections.singletonMap("id", Sort.Direction.ASC));
-        reader.setPageSize(500);
+        reader.setPageSize(100);
         return reader;
     }
 

--- a/src/main/java/com/boostcamp/zzimkong/config/batch/SpaceBatchConfig.java
+++ b/src/main/java/com/boostcamp/zzimkong/config/batch/SpaceBatchConfig.java
@@ -42,7 +42,7 @@ public class SpaceBatchConfig {
     @Bean
     public Step finishSpaceStep(JobRepository jobRepository) {
         return new StepBuilder("finishSpaceStep", jobRepository)
-                .<SpaceModelResult, SpaceModelResult> chunk(500, transactionManager)
+                .<SpaceModelResult, SpaceModelResult> chunk(100, transactionManager)
                 .reader(readerSpace())
                 .writer(writerSpace())
                 .build();
@@ -55,7 +55,7 @@ public class SpaceBatchConfig {
         reader.setMethodName("findByStatusPushed");
         reader.setArguments(Collections.singletonList(false));
         reader.setSort(Collections.singletonMap("id", Sort.Direction.ASC));
-        reader.setPageSize(500);
+        reader.setPageSize(100);
         return reader;
     }
 

--- a/src/main/java/com/boostcamp/zzimkong/controller/dto/VideoUploadRequest.java
+++ b/src/main/java/com/boostcamp/zzimkong/controller/dto/VideoUploadRequest.java
@@ -22,11 +22,10 @@ public class VideoUploadRequest {
     @NotBlank
     private String title;
 
-    public VideoUploadRequestDto toServiceDto(String videoUploadUrl, Long messageId) {
+    public VideoUploadRequestDto toServiceDto(String videoUploadUrl) {
         return new VideoUploadRequestDto(
                 title,
-                videoUploadUrl,
-                messageId
+                videoUploadUrl
         );
     }
 }

--- a/src/main/java/com/boostcamp/zzimkong/domain/furniture/FurnitureModelResult.java
+++ b/src/main/java/com/boostcamp/zzimkong/domain/furniture/FurnitureModelResult.java
@@ -104,7 +104,7 @@ public class FurnitureModelResult extends BaseEntity {
                 null,
                 2,
                 false,
-                true
+                false
         );
     }
 }

--- a/src/main/java/com/boostcamp/zzimkong/domain/space/SpaceModelResult.java
+++ b/src/main/java/com/boostcamp/zzimkong/domain/space/SpaceModelResult.java
@@ -11,6 +11,8 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+import static com.boostcamp.zzimkong.utils.ZzimkongConstant.*;
+
 @Entity
 @Getter
 @Table(name = "space_model_result")
@@ -25,7 +27,7 @@ public class SpaceModelResult extends BaseEntity {
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_space_model_result_user"), nullable = false)
     private User user;
 
-    @Column(name = "message_id", nullable = false)
+    @Column(name = "message_id", nullable = true)
     private Long messageId;
 
     @Enumerated(EnumType.STRING)
@@ -67,7 +69,6 @@ public class SpaceModelResult extends BaseEntity {
     private LocalDateTime finishedDate;
 
     public SpaceModelResult(User user,
-                            Long messageId,
                             StatusCode statusCode,
                             String statusMessage,
                             String uploadFileName,
@@ -79,7 +80,6 @@ public class SpaceModelResult extends BaseEntity {
                             boolean deleted
     ) {
         this.user = user;
-        this.messageId = messageId;
         this.statusCode = statusCode;
         this.statusMessage = statusMessage;
         this.storeFileUrl = storeFileUrl;
@@ -91,19 +91,26 @@ public class SpaceModelResult extends BaseEntity {
         this.deleted = deleted;
     }
 
-    public static SpaceModelResult of(User user, Long messageId, String uploadFileName) {
+    public static SpaceModelResult of(User user, String uploadFileName, String storeFileUrl) {
         return new SpaceModelResult(
                 user,
-                messageId,
                 StatusCode.PROCESSING,
                 null,
                 uploadFileName,
                 false,
-                null,
+                getStoreFileName(storeFileUrl),
                 null,
                 2,
                 false,
-                true
+                false
         );
+    }
+
+    public void changeId(Long id) {
+        this.messageId = id;
+    }
+
+    private static String getStoreFileName(String storeFileUrl) {
+        return SPACE_RESULT_URL + storeFileUrl.split(REGEX)[LAST_IDX] + SUFFIX;
     }
 }

--- a/src/main/java/com/boostcamp/zzimkong/repository/modelresult/SpaceResultRepository.java
+++ b/src/main/java/com/boostcamp/zzimkong/repository/modelresult/SpaceResultRepository.java
@@ -67,4 +67,6 @@ public interface SpaceResultRepository extends JpaRepository<SpaceModelResult, L
     @Modifying(clearAutomatically = true)
     @Query("update SpaceModelResult f set f.statusPushed = true where f.statusPushed = :statusPushed and f.statusCode != 'PROCESSING'")
     int updateStatusPushed(@Param("statusPushed") Boolean statusPushed);
+
+    Optional<SpaceModelResult> findByStoreFileUrl(String storeFileUrl);
 }

--- a/src/main/java/com/boostcamp/zzimkong/service/FileService.java
+++ b/src/main/java/com/boostcamp/zzimkong/service/FileService.java
@@ -45,9 +45,11 @@ public class FileService {
         );
 
         spaceResultRepository.save(
-                SpaceModelResult.of(findUser, videoUploadRequestDto.getMessageId(),
-                        videoUploadRequestDto.getUploadFileName())
-        );
+                SpaceModelResult.of(
+                        findUser,
+                        videoUploadRequestDto.getUploadFileName(),
+                        videoUploadRequestDto.getStoreFileUrl()
+                ));
         SpaceUploadFile saveSpaceUploadFile = spaceRepository.save(spaceUploadFile);
         return VideoFileSaveResponse.from(saveSpaceUploadFile);
     }

--- a/src/main/java/com/boostcamp/zzimkong/service/dto/VideoUploadRequestDto.java
+++ b/src/main/java/com/boostcamp/zzimkong/service/dto/VideoUploadRequestDto.java
@@ -9,5 +9,4 @@ public class VideoUploadRequestDto {
 
     private String uploadFileName;
     private String storeFileUrl;
-    private Long messageId;
 }

--- a/src/main/java/com/boostcamp/zzimkong/support/SignedUrlGenerator.java
+++ b/src/main/java/com/boostcamp/zzimkong/support/SignedUrlGenerator.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.FileInputStream;
@@ -15,18 +16,29 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Component
 public class SignedUrlGenerator {
-    private final Storage storage;;
 
-    public SignedUrlGenerator(Storage storage) {
+    private static final String CLASS_PATH = "src/main/resources/";
+
+    private final Storage storage;
+    private final String bucket;
+    private final String credentials;
+
+    public SignedUrlGenerator(
+            Storage storage,
+            @Value("${spring.cloud.gcp.storage.bucket}") String bucket,
+            @Value("${spring.cloud.gcp.storage.credentials.location}") String credentials
+    ) {
         this.storage = storage;
+        this.bucket = bucket;
+        this.credentials = credentials;
     }
 
     public String generateSignedUrl(String objectPath) throws IOException {
         URL signedUrl = storage.signUrl(
-                BlobInfo.newBuilder(BlobId.of("버킷 이름", objectPath)).build(),
+                BlobInfo.newBuilder(BlobId.of(bucket, objectPath)).build(),
                 5, TimeUnit.MINUTES, // URL의 유효 시간을 5분으로 설정
                 Storage.SignUrlOption.signWith(ServiceAccountCredentials.fromStream(
-                        new FileInputStream("key.json 경로")))
+                        new FileInputStream(CLASS_PATH + credentials)))
         );
         return signedUrl.toString();
     }

--- a/src/main/java/com/boostcamp/zzimkong/support/file/FileConverter.java
+++ b/src/main/java/com/boostcamp/zzimkong/support/file/FileConverter.java
@@ -10,7 +10,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.boostcamp.zzimkong.utils.ZzimkongConstant.SPACE_URI;
+import static com.boostcamp.zzimkong.utils.ZzimkongConstant.STORAGE_URL;
+
 public class FileConverter {
+
     public static RawFileData convertVideoFile(final MultipartFile file, final UuidHolder uuidHolder) {
         if (file == null || file.isEmpty()) {
             return null;
@@ -54,5 +58,9 @@ public class FileConverter {
                             }
                         }
                 ).collect(Collectors.toList());
+    }
+
+    public static String createFileStoreUrl(String fileName, String bucket) {
+        return String.format("%s/%s/%s%s", STORAGE_URL, bucket, SPACE_URI, fileName);
     }
 }

--- a/src/main/java/com/boostcamp/zzimkong/support/file/GCPFileUploader.java
+++ b/src/main/java/com/boostcamp/zzimkong/support/file/GCPFileUploader.java
@@ -1,21 +1,27 @@
 package com.boostcamp.zzimkong.support.file;
 
 import com.boostcamp.zzimkong.domain.file.RawFileData;
+import com.boostcamp.zzimkong.domain.message.Message;
+import com.boostcamp.zzimkong.domain.space.SpaceModelResult;
 import com.boostcamp.zzimkong.exception.InvalidDurationException;
 import com.boostcamp.zzimkong.exception.UnExistFileException;
+import com.boostcamp.zzimkong.repository.MessageRepository;
+import com.boostcamp.zzimkong.repository.modelresult.SpaceResultRepository;
+import com.boostcamp.zzimkong.support.MessageConsumer;
 import com.drew.imaging.ImageMetadataReader;
 import com.drew.imaging.ImageProcessingException;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.MetadataException;
 import com.drew.metadata.mp4.Mp4Directory;
-import com.google.api.client.util.IOUtils;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.*;
 import java.nio.ByteBuffer;
@@ -24,65 +30,63 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static com.boostcamp.zzimkong.utils.ZzimkongConstant.START_IDX;
-import static com.boostcamp.zzimkong.utils.ZzimkongConstant.UPLOAD_FAIL_MESSAGE;
+import static com.boostcamp.zzimkong.utils.ZzimkongConstant.*;
 
 @Slf4j
 @Component
+@Transactional
 public class GCPFileUploader {
 
     private final Storage storage;
 
     private final String bucket;
 
+    private final MessageConsumer messageConsumer;
+
+    private final SpaceResultRepository spaceResultRepository;
+
     private static final int MAX = 600;
     private static final int MIN = 120;
     private static final int CHUNK_SIZE = 1024 * 1024 * 200;
+    private static final int START_IDX = 0;
     private static final int DEST_POS = 0;
     private static final int INITIAL_SIZE = 0;
     public static final String STORAGE_URL = "https://storage.googleapis.com";
     public static final String SPACE_URI = "space/video/";
     public static final String FURNITURE_URI = "furniture/img/";
-    public static final String UPLOAD_PREFIX = "upload";
-    public static final String UPLOAD_SUFFIX = "tmp";
 
     public GCPFileUploader(
             Storage storage,
-            @Value("${spring.cloud.gcp.storage.bucket}") String bucket
+            @Value("${spring.cloud.gcp.storage.bucket}") String bucket,
+            MessageConsumer messageConsumer,
+            SpaceResultRepository spaceResultRepository
     ) {
         this.storage = storage;
         this.bucket = bucket;
+        this.messageConsumer = messageConsumer;
+        this.spaceResultRepository = spaceResultRepository;
     }
 
-    public String uploadVideo(final RawFileData fileData) {
-        File tempFile = null;
+    @Async
+    public void handleUploadProcess(final RawFileData fileData) {
+        try {
+            uploadVideo(fileData);
+            messagePushProcess(fileData.getStoreFileName());
 
-        try (InputStream inputStream = fileData.getContent()) {
-            tempFile = File.createTempFile(UPLOAD_PREFIX, UPLOAD_SUFFIX);
-
-            try (FileOutputStream out = new FileOutputStream(tempFile)) {
-                IOUtils.copy(inputStream, out);
-            }
-
-            try (InputStream durationCheckStream = new FileInputStream(tempFile);
-                 InputStream uploadStream = new FileInputStream(tempFile)) {
-
-                validateFileExists(fileData);
-                validateFileDuration(durationCheckStream);
-
-                return sendVideoToStorage(fileData, uploadStream);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } finally {
-            if (tempFile != null && tempFile.exists()) {
-                tempFile.delete();
-            }
+            System.out.println(UPLOAD_SUCCESS_MESSAGE);
+        } catch (Exception e) {
+            throw new RuntimeException(UPLOAD_FAIL_MESSAGE);
         }
     }
 
-    private String sendVideoToStorage(final RawFileData fileData, InputStream inputStream) {
-        try {
+    public String uploadVideo(final RawFileData fileData) {
+        validateFileExists(fileData);
+        validateFileDuration(fileData.getContent());
+        return sendVideoToStorage(fileData);
+    }
+
+    private String sendVideoToStorage(final RawFileData fileData) {
+        try (final InputStream inputStream = fileData.getContent()) {
             String fileName = fileData.getStoreFileName();
             byte[] fileBytes = inputStream.readAllBytes();
             int numChunks = (int) Math.ceil((double) fileBytes.length / CHUNK_SIZE);
@@ -98,11 +102,7 @@ public class GCPFileUploader {
         }
     }
 
-    private static void fileMemoryLoad(
-            int numChunks,
-            byte[] fileBytes,
-            List<CompletableFuture<byte[]>> futures
-    ) {
+    private static void fileMemoryLoad(int numChunks, byte[] fileBytes, List<CompletableFuture<byte[]>> futures) {
         for (int chunkIdx = START_IDX; chunkIdx < numChunks; chunkIdx++) {
             final int start = chunkIdx * CHUNK_SIZE;
             final int end = Math.min(start + CHUNK_SIZE, fileBytes.length);
@@ -118,11 +118,7 @@ public class GCPFileUploader {
                 .join();
     }
 
-    private void fileUpload(
-            RawFileData fileData,
-            String fileName,
-            List<CompletableFuture<byte[]>> futures
-    ) throws IOException {
+    private void fileUpload(RawFileData fileData, String fileName, List<CompletableFuture<byte[]>> futures) throws IOException {
         BlobInfo blobInfo = BlobInfo.newBuilder(bucket, SPACE_URI + fileName)
                 .setContentType(fileData.getContentType())
                 .build();
@@ -182,15 +178,27 @@ public class GCPFileUploader {
         }
     }
 
-    private static double getVideoDuration(InputStream videoStream)
-            throws ImageProcessingException, IOException, MetadataException {
+    private static boolean isNotInRange(double videoDuration) {
+        return videoDuration >= MAX || videoDuration <= MIN;
+    }
+
+    private static double getVideoDuration(InputStream videoStream) throws ImageProcessingException, IOException, MetadataException {
         Metadata metadata = null;
         metadata = ImageMetadataReader.readMetadata(videoStream);
         Directory directory = metadata.getFirstDirectoryOfType(Mp4Directory.class);
         return Math.floor(directory.getDouble(Mp4Directory.TAG_DURATION_SECONDS));
     }
 
-    private static boolean isNotInRange(double videoDuration) {
-        return videoDuration >= MAX || videoDuration <= MIN;
+    private void messagePushProcess(String storeFileName) {
+        String videoUploadUrl = FileConverter.createFileStoreUrl(storeFileName, bucket);
+        Long messageID = messageConsumer.sendSpaceMessage(videoUploadUrl, SPACE_TYPE);
+
+        SpaceModelResult findSpaceModelResult = spaceResultRepository.findByStoreFileUrl(getStoreFileName(videoUploadUrl))
+                .orElseThrow();
+        findSpaceModelResult.changeId(messageID);
+    }
+
+    private static String getStoreFileName(String storeFileUrl) {
+        return SPACE_RESULT_URL + storeFileUrl.split(REGEX)[LAST_IDX] + SUFFIX;
     }
 }

--- a/src/main/java/com/boostcamp/zzimkong/utils/ZzimkongConstant.java
+++ b/src/main/java/com/boostcamp/zzimkong/utils/ZzimkongConstant.java
@@ -6,9 +6,16 @@ public abstract class ZzimkongConstant {
     public static final String FURNITURE_TYPE = "가구";
     public static final String SPACE_TYPE = "공간";
     public static final int START_IDX = 0;
+    public static final String STORAGE_URL = "https://storage.googleapis.com";
+    public static final String SPACE_URI = "space/video/";
+    public static final String SPACE_RESULT_URL = "space/ply/";
+    public static final String REGEX = "/";
+    public static final int LAST_IDX = 6;
+    public static final String SUFFIX = ".ply";
 
     // Exception Message
     public static final String UPLOAD_FAIL_MESSAGE = "파일 업로드에 실패했습니다.";
     public static final String EMAIL_FAIL_MESSAGE = "이메일 전송 실패";
     public static final String EMAIL_SUCCESS_MESSAGE = "이메일 전송 성공";
+    public static final String UPLOAD_SUCCESS_MESSAGE = "비동기 업로드 완료";
 }


### PR DESCRIPTION
## Overview
- 스토리지 업로드와 VM 업로드를 분리하여 request latency를 줄이는 것을 목표로 합니다.

## Change log
- FileUploadApiController
- SpaceResultRepository
- FileConverter
- GCPFileUploader

## To Reviewer
- 스토리지 업로드 로직은 비동기처리 했습니다. 
- 서버에 동영상을 업로드한 후 유저에게 response 했을 때 재구성 목록이 수정되도록 Space Result 테이블에 save 쿼리는 동기적으로 수행하고 그 외 (스토리지 업로드, 큐 푸시 등)은 비동기적으로 처리합니다.

- 결과
![image](https://github.com/bcatcv5/zzimkong-backend/assets/90328527/557cfa1a-a5e4-4c05-9ad2-a5bed8e6b08c)
파일 업로드 결과 테이블 수정 시간은 00:48:48이고

![image](https://github.com/bcatcv5/zzimkong-backend/assets/90328527/1c2d7850-436e-40bf-84f9-ba0564c92ca4)
스토리지 업로드 시간은 00:49:22이며 재구성 목록 페이지에는 00:48:48에 반영됩니다.

## Issue Tags
- fixed: #29 
